### PR TITLE
Fix/update sprockets gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.0.11
+
+**Update sprockets gem**
+
+* Updated sprockets gem;
+
+Upgrade sprockets to version 3.7.2 or later. Due to CVE-2018-3760.
+
 ### 0.0.10
 
 **Update csv data**

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 # Support for iCalendar files
 gem 'icalendar', '~> 2.4', '>= 2.4.1'
+
+gem 'sprockets', '>= 3.7.2'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 # Support for iCalendar files
 gem 'icalendar', '~> 2.4', '>= 2.4.1'
-
+# Force sprockets gem to 3.7.2 or above due to CVE-2018-3760. Read more: https://nvd.nist.gov/vuln/detail/CVE-2018-3760
 gem 'sprockets', '>= 3.7.2'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     crass (1.0.3)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
@@ -127,7 +127,7 @@ GEM
     pg (0.21.0)
     public_suffix (3.0.1)
     puma (3.11.0)
-    rack (2.0.3)
+    rack (2.0.6)
     rack-proxy (0.6.3)
       rack
     rack-test (0.8.2)
@@ -180,7 +180,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -241,6 +241,7 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets (>= 3.7.2)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
@@ -248,4 +249,4 @@ DEPENDENCIES
   webpacker
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
This is the initial work to upgrade sprockets to version 3.7.2 or later. Due to CVE-2018-3760.

**CVE-2018-3760**
Specially crafted requests can be used to access files that exist on the filesystem that is outside an application's root directory, when the Sprockets server is used in production.

All users running an affected release should either upgrade or use one of the work arounds immediately.