### PR TITLE
use old scrollTo params for IE

### DIFF
--- a/app/assets/stylesheets/components-vue/_filters.scss
+++ b/app/assets/stylesheets/components-vue/_filters.scss
@@ -33,7 +33,7 @@ $total-size: rem-calc(25);
     background-color: white;
     padding: rem-calc(12);
 
-    position: fixed;
+    position: absolute;
     right: 0;
     bottom: 0;
     left: 0;

--- a/app/javascript/components/back_to_top/BackToTop.vue
+++ b/app/javascript/components/back_to_top/BackToTop.vue
@@ -6,9 +6,12 @@
 
 <script>
   import { eventHub } from '../../home.js'
+  import mixinScroll from '../../mixins/scroll'
 
   export default {
     name: 'back-to-top',
+
+    mixins: [mixinScroll],
 
     created () {
       eventHub.$on('backToTop', this.scroll)
@@ -18,7 +21,7 @@
       scroll (behavior = 'instant') {
         const currentEvent = this.$store.state.filters.currentEvent
 
-        window.scrollTo({ top: currentEvent, behavior: behavior })
+        this.scrollTo({ top: currentEvent, behavior: behavior })
       }
     }
   }  

--- a/app/javascript/components/scroll_nav/ScrollNav.vue
+++ b/app/javascript/components/scroll_nav/ScrollNav.vue
@@ -36,6 +36,12 @@
       }
     },
 
+    computed: {
+      isIE () {
+        return Boolean(window.navigator.userAgent.match(/(MSIE|Trident)/))
+      }
+    },
+
     mounted () {
       // set the initial window width
       this.windowWidth = window.innerWidth
@@ -77,8 +83,13 @@
       // link that has been clicked
       scroll (year) {
         const offset = document.getElementById('year-' + year).offsetTop
-        
-        window.scrollTo({ top: offset - this.triggerOffset, behavior: 'smooth' })
+        const scrollTo = offset - this.triggerOffset
+
+        if (this.isIE) {
+          window.scrollTo(0, scrollTo)
+        } else {
+          window.scrollTo({ top: scrollTo, behavior: 'smooth' })
+        }
       },
 
       // add scroll magic event listener for each nav item

--- a/app/javascript/components/scroll_nav/ScrollNav.vue
+++ b/app/javascript/components/scroll_nav/ScrollNav.vue
@@ -16,9 +16,12 @@
 <script>
   import ScrollMagic from 'scrollmagic'
   import { eventHub } from '../../home.js'
+  import mixinScroll from '../../mixins/scroll'
 
   export default {
     name: 'scroll-nav',
+
+    mixins: [mixinScroll],
 
     props: {
       navArray: {
@@ -33,12 +36,6 @@
         navY: 0,
         triggerOffset: 0,
         windowWidth: 0
-      }
-    },
-
-    computed: {
-      isIE () {
-        return Boolean(window.navigator.userAgent.match(/(MSIE|Trident)/))
       }
     },
 
@@ -85,11 +82,7 @@
         const offset = document.getElementById('year-' + year).offsetTop
         const scrollTo = offset - this.triggerOffset
 
-        if (this.isIE) {
-          window.scrollTo(0, scrollTo)
-        } else {
-          window.scrollTo({ top: scrollTo, behavior: 'smooth' })
-        }
+        this.scrollTo({ top: scrollTo, behavior: 'smooth' })
       },
 
       // add scroll magic event listener for each nav item

--- a/app/javascript/mixins/scroll.js
+++ b/app/javascript/mixins/scroll.js
@@ -1,0 +1,17 @@
+export default {
+  computed: {
+    isIE () {
+      return Boolean(window.navigator.userAgent.match(/(MSIE|Trident)/))
+    }
+  },
+
+  methods: {
+    scrollTo ({ left=0, top=0, behavior=nil }) {
+      if (this.isIE) {
+        window.scrollTo(left, top)
+      } else {
+        window.scrollTo({ left, top, behavior })
+      }
+    }
+  }
+}


### PR DESCRIPTION
Object params don't work for IE scroll. Check for IE and using old param style (no smooth scroll) if it is IE, otherwise carry on as normal. Note smooth scroll doesn't seem to work in Safari, but that's fine.

Also fix ie bug where filter controls have jumped out of their filter pane and are across the bottom of the whole screen always.
